### PR TITLE
Ignoring wrong devices

### DIFF
--- a/xcomfort/bridge.py
+++ b/xcomfort/bridge.py
@@ -85,9 +85,12 @@ class Bridge:
         
         if 'devices' in payload:
             for device in payload['devices']:
-                device_id = device['deviceId']
-                name = device['name']
-                dimmable = device['dimmable']
+                try:
+                    device_id = device['deviceId']
+                    name = device['name']
+                    dimmable = device['dimmable']
+                except KeyError:
+                    continue
                 state = LightState(device['switch'], device['dimmvalue'])
 
                 light = Light(self, device_id, name, dimmable, state)

--- a/xcomfort/bridge.py
+++ b/xcomfort/bridge.py
@@ -66,18 +66,24 @@ class Bridge:
         self._devices[device.device_id] = device
 
     def _handle_SET_DEVICE_STATE(self, payload):
-        device = self._devices[payload['deviceId']]
+        try:
+            device = self._devices[payload['deviceId']]
 
-        if isinstance(device, Light):
-            device.state.on_next(LightState(payload['switch'], payload['dimmvalue']))
+            if isinstance(device, Light):
+                device.state.on_next(LightState(payload['switch'], payload['dimmvalue']))
+        except KeyError:
+            return
     
     def _handle_SET_STATE_INFO(self, payload):
         for item in payload['item']:
-            deviceId = item['deviceId']
-            device = self._devices[deviceId]
+            try:
+                deviceId = item['deviceId']
+                device = self._devices[deviceId]
 
-            if isinstance(device, Light):
-                device.state.on_next(LightState(item['switch'], item['dimmvalue']))
+                if isinstance(device, Light):
+                    device.state.on_next(LightState(item['switch'], item['dimmvalue']))
+            except KeyError:
+                continue
 
     def _handle_SET_ALL_DATA(self, payload):
         if 'lastItem' in payload:


### PR DESCRIPTION
The change just omits all devices that do not have the keys that need to be processed. They are simply skipped.

The reason for that fix is that the integration in home assistant was not working. After this fix it was possible to enable the component correctly and all devices were found.