### PR TITLE
Update shade support

### DIFF
--- a/xcomfort/bridge.py
+++ b/xcomfort/bridge.py
@@ -41,11 +41,12 @@ class CompState:
     __repr__ = __str__
 
 class Comp:
-    def __init__(self, bridge, comp_id, comp_type, name: str):
+    def __init__(self, bridge, comp_id, comp_type, name: str, payload: dict):
         self.bridge = bridge
         self.comp_id = comp_id
         self.comp_type = comp_type
         self.name = name
+        self.payload = payload
 
         self.state = rx.subject.BehaviorSubject(None)
 
@@ -53,7 +54,7 @@ class Comp:
         self.state.on_next(CompState(payload))
 
     def __str__(self):
-        return f"Comp({self.comp_id}, \"{self.name}\", comp_type: {self.comp_type})"
+        return f'Comp({self.comp_id}, "{self.name}", comp_type: {self.comp_type}, payload: {self.payload})'
 
     __repr__ = __str__
 
@@ -240,7 +241,7 @@ class Bridge:
         name = payload['name']
         comp_type = payload["compType"]
 
-        return Comp(self, comp_id, comp_type, name)
+        return Comp(self, comp_id, comp_type, name, payload)
 
     def _create_device_from_payload(self, payload):
         device_id = payload['deviceId']
@@ -253,7 +254,7 @@ class Bridge:
             return Light(self, device_id, name, dimmable)
 
         if dev_type == 102:
-            return Shade(self, device_id, name, comp_id)
+            return Shade(self, device_id, name, comp_id, payload)
 
         if dev_type == 440:
             return Heater(self, device_id, name, comp_id)

--- a/xcomfort/devices.py
+++ b/xcomfort/devices.py
@@ -113,9 +113,10 @@ class Heater(BridgeDevice):
         self.comp_id = comp_id
 
 class Shade(BridgeDevice):
-    def __init__(self, bridge, device_id, name, comp_id):
+    def __init__(self, bridge, device_id, name, comp_id, payload):
         BridgeDevice.__init__(self, bridge, device_id, name)
 
+        self.payload = payload
         self.comp_id = comp_id
     
     async def send_state(self, state):

--- a/xcomfort/devices.py
+++ b/xcomfort/devices.py
@@ -1,6 +1,6 @@
 from contextlib import nullcontext
 import rx
-from .messages import Messages
+from .messages import Messages, ShadeOperationState
 
 class DeviceState:
     def __init__(self, payload):
@@ -40,6 +40,38 @@ class HeaterState(DeviceState):
 
     __repr__ = __str__
 
+
+class ShadeState(DeviceState):
+
+    def __init__(self):
+        self.raw = {}
+        self.current_state: int | None = None
+        self.is_safety_enabled: bool | None = None
+        self.position: int | None = None
+
+    def update_from_partial_state_update(self, payload: dict) -> None:
+        self.raw.update(payload)
+
+        if (current_state := payload.get("curstate")) is not None:
+            self.current_state = current_state
+
+        if (safety := payload.get("shSafety")) is not None:
+            self.is_safety_enabled = safety != 0
+
+        if (position := payload.get("shPos")) is not None:
+            self.position = position
+
+    @property
+    def is_closed(self) -> bool | None:
+        if (self.position is None) or (0 < self.position < 100):
+            # It's not fully closed or open and can move both ways, or we don't know
+            return None
+
+        # It's fully extended, i.e. "closed"
+        return self.position == 100
+
+    def __str__(self) -> str:
+        return f"ShadeState(current_state={self.current_state} is_safety_enabled={self.is_safety_enabled} position={self.position} raw={self.raw})"
 
 class BridgeDevice:
     def __init__(self, bridge, device_id, name):
@@ -116,17 +148,52 @@ class Shade(BridgeDevice):
     def __init__(self, bridge, device_id, name, comp_id, payload):
         BridgeDevice.__init__(self, bridge, device_id, name)
 
+        self.component = bridge._comps.get(comp_id)
         self.payload = payload
+
+        # We get partial updates of shade state across different state updates, so
+        # we aggregate them via this object
+        self.__shade_state = ShadeState()
+
         self.comp_id = comp_id
-    
-    async def send_state(self, state):
-        await self.bridge.send_message(Messages.SET_DEVICE_SHADING_STATE, {"deviceId":self.device_id,"state":state})
-    
+
+    @property
+    def supports_go_to(self) -> bool | None:
+        # "go to" is whether a specific position can be set, i.e. 50 meaning halfway down
+        # Not all actuators support this, even if they can be stopped at arbitrary positions.
+        if (component := self.bridge._comps.get(self.comp_id)) is not None:
+            return component.comp_type == 86 and self.payload.get("shRuntime") == 1
+        return None
+
+    def handle_state(self, payload):
+        self.__shade_state.update_from_partial_state_update(payload)
+        self.state.on_next(self.__shade_state)
+
+    async def send_state(self, state, **kw):
+        if self.__shade_state.is_safety_enabled:
+            # Do not trigger changes if safety is on. The official xcomfort client does
+            # this check in the client, so we do that too just to be safe.
+            return
+
+        await self.bridge.send_message(
+            Messages.SET_DEVICE_SHADING_STATE, {"deviceId": self.device_id, "state": state, **kw}
+        )
+
     async def move_down(self):
-        await self.send_state(1)
-    
+        await self.send_state(ShadeOperationState.CLOSE)
+
     async def move_up(self):
-        await self.send_state(3)
-    
+        await self.send_state(ShadeOperationState.OPEN)
+
     async def move_stop(self):
-        await self.send_state(2)
+        if self.__shade_state.is_safety_enabled:
+            return
+
+        await self.send_state(ShadeOperationState.STOP)
+
+    async def move_to_position(self, position: int):
+        assert self.supports_go_to and 0 <= position <= 100
+        await self.send_state(ShadeOperationState.GO_TO, value=position)
+
+    def __str__(self) -> str:
+        return f"<Shade device_id={self.device_id} name={self.name} state={self.state} supports_go_to={self.supports_go_to}>"

--- a/xcomfort/messages.py
+++ b/xcomfort/messages.py
@@ -98,3 +98,15 @@ class Messages(IntEnum):
     NACK_INFO_INVALID_ACTION = -98
     NACK_INFO_DEVICE_NOT_DIMMABLE = -99
     NACK_INFO_UNKNOWN_DEVICE = -100
+
+class ShadeOperationState(IntEnum):
+    OPEN = 0
+    CLOSE = 1
+    STOP = 2
+    STEP_DOWN = 3
+    STEP_UP = 4
+    GO_TO = 5
+    CALIBRATION = 10
+    LOCK = 11
+    UNLOCK = 12
+    QUIT = 13


### PR DESCRIPTION
First, thanks for the great work, @jankrib :)

I have two different kinds of shades. Both types would react to the `move_down` operation, but not the two other operations, where I found the state constants sent to differ from those that the public app makes.

Some of my shades support setting a direct position, e.g. 50%, while some of the other shades do not. I think the logic for detecting this should be right, but hard to tell through reverse engineering and guessing :)

@jankrib Does the existing code move shades correctly for you? If so we'll need to detect differences in components/state somehow so my changes do not break things.

Here's the raw component data I get on an awning shade not supporting setting a direct position:

```python
raw_component = {'compId': 8694179, 'compType': 86, 'name': 'Pergola - høyre', 'icon': 637, 'order': 72, 'versionFW': '7.1', 'info': [{'text': '1111', 'type': 2, 'icon': 1, 'value': '3'}, {'text': '1119', 'type': 2, 'icon': 1}]}
raw_state = {'deviceId': 10219, 'name': 'Pergola - høyre', 'icon': 633, 'order': 113, 'compId': 8694179, 'chId': 0, 'cat': 0, 'devType': 102, 'configured': True, 'shType': 3, 'shControl': 3, 'shRuntime': 60, 'shCounterRuntime': 5000, 'shStepDur': 300, 'shSafety': 0, 'shSafetyPos': 0, 'shCounterPause': 800, 'shHasSlats': False, 'shSlatRuntime': 300, 'shInvertOutput': False, 'curstate': 1, 'shPos': 100, 'shSlatPos': 255, 'shCalInfo': 0, 'cloudUsage': True, 'info': [{'text': '1109', 'type': 2, 'icon': 1, 'value': '30'}, {'text': '1132', 'type': 1, 'value': '100%'}]}
```

This one does support setting a position, e.g. 50% closed:

```python
raw_component = {'compId': 8627654, 'compType': 86, 'name': 'Screen 4 - høyre vindu', 'icon': 637, 'order': 50, 'versionFW': '7.1', 'info': [{'text': '1111', 'type': 2, 'icon': 1, 'value': '2'}, {'text': '1119', 'type': 2, 'icon': 1}]}
raw_state = {'deviceId': 190, 'name': 'Screen 4 - høyre vindu', 'icon': 631, 'order': 71, 'compId': 8627654, 'chId': 0, 'cat': 0, 'devType': 102, 'configured': True, 'shType': 1, 'shControl': 2, 'shRuntime': 1, 'shCounterRuntime': 5000, 'shStepDur': 300, 'shSafety': 0, 'shSafetyPos': 0, 'shCounterPause': 800, 'shHasSlats': False, 'shSlatRuntime': 0, 'shInvertOutput': False, 'curstate': 1, 'shPos': 100, 'shSlatPos': 255, 'shCalInfo': 1, 'cloudUsage': True, 'info': [{'text': '1109', 'type': 2, 'icon': 1, 'value': '41'}, {'text': '1132', 'type': 1, 'value': '100%'}]}
```


