### PR TITLE
Fix "local variable 'temperature' referenced before assignment"

### DIFF
--- a/xcomfort/devices.py
+++ b/xcomfort/devices.py
@@ -128,6 +128,8 @@ class RcTouch(BridgeDevice):
 
     def handle_state(self, payload):
         print(f"RcTouchState::: {payload}")
+        temperature = None
+        humidity = None
         if 'info' in payload:
             for info in payload['info']:
                 if info['text'] == "1222":
@@ -135,7 +137,8 @@ class RcTouch(BridgeDevice):
                 if info['text'] == "1223":
                     humidity = float(info['value'])
 
-        self.state.on_next(RcTouchState(temperature, humidity, payload))
+        if temperature is not None and humidity is not None:
+            self.state.on_next(RcTouchState(temperature, humidity, payload))
 
 
 class Heater(BridgeDevice):


### PR DESCRIPTION
With the latest bridge firmware update it seems SET_STATE_INFO may contain the same deviceId multiple times for RcTouch devices, and not all instances include the temperature and humidity atrtibutes, leading to unassigned local variables referenced when trying to update the state

Fixed by only updating TcTouch state if both attributes are included in the message payload